### PR TITLE
feat(middleware::body-parser): new FAST json parsing

### DIFF
--- a/examples/body-parser.js
+++ b/examples/body-parser.js
@@ -1,14 +1,27 @@
 import nanoexpress from '../src/nanoexpress.js';
-import bodyParser from '../src/packed/middlewares/body-parser';
+import bodyParser from '../src/packed/middlewares/body-parser.js';
 
 const app = nanoexpress();
 
-app.use(bodyParser({ json: true }));
+app.use(bodyParser({ json: true, experimentalJsonParse: true }));
 
 app.get('/', (req, res) => res.end('ok'));
 
-app.post('/', (req, res) => {
-  return res.send({ status: 'ok', body: req.body });
-});
+app.post(
+  '/',
+  {
+    schema: {
+      body: {
+        type: 'object',
+        properties: {
+          foo: { type: 'string' }
+        }
+      }
+    }
+  },
+  (req, res) => {
+    return res.send({ status: 'ok', body: req.body });
+  }
+);
 
 app.listen(4002);

--- a/examples/body-parser.js
+++ b/examples/body-parser.js
@@ -3,7 +3,7 @@ import bodyParser from '../src/packed/middlewares/body-parser.js';
 
 const app = nanoexpress();
 
-app.use(bodyParser({ json: true, experimentalJsonParse: true }));
+app.use(bodyParser({ json: true, experimentalJsonParse: false }));
 
 app.get('/', (req, res) => res.end('ok'));
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nanoexpress-pro",
-  "version": "1.10.14",
+  "version": "1.11.0",
   "description": "Nano-framework for Node.js powered by uWebSockets.js",
   "type": "module",
   "main": "src/nanoexpress.js",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "busboy": "^0.3.1",
     "cookie": "^0.x",
     "fast-json-stringify": "^1.16.3",
+    "turbo-json-parse": "github:dalisoft/turbo-json-parse",
     "uWebSockets.js": "github:uNetworking/uWebSockets.js#binaries"
   },
   "devDependencies": {

--- a/src/Route.js
+++ b/src/Route.js
@@ -197,16 +197,13 @@ export default class Route {
         turboJsonParse(_schema.body, {
           defaults: false,
           validate: false,
-          fullMatch: false,
+          fullMatch: true,
           buffer: false
         });
       validation = _schema && prepareValidation(_ajv, _schema);
       // eslint-disable-next-line prefer-const
       responseSchema = _schema && validation && validation.responseSchema;
 
-      _schema &&
-        _schema.body &&
-        console.log(_schema.body, experimentalBodyParser);
       isNotFoundHandler = routeFunction.handler === 2;
       if (
         method !== 'options' &&

--- a/src/packed/middlewares/body-parser.js
+++ b/src/packed/middlewares/body-parser.js
@@ -1,27 +1,39 @@
 import { parse } from 'querystring';
 
-export default ({ json = true, urlEncoded = true } = {}) => {
-  const middleware = async (req) => {
+export default ({
+  json = true,
+  experimentalJsonParse = false,
+  urlEncoded = true
+} = {}) => {
+  const middleware = async (req, { fastBodyParse }) => {
     const { headers, body } = req;
 
     if (headers && body) {
       const contentType = headers['content-type'];
       if (contentType) {
         if (json && contentType.indexOf('/json') !== -1) {
-          req.body = JSON.parse(
-            typeof body === 'string' ? body : body.toString()
+          console.log(
+            experimentalJsonParse,
+            fastBodyParse,
+            {
+              check: experimentalJsonParse && fastBodyParse
+            },
+            body
           );
+          if (experimentalJsonParse && fastBodyParse !== undefined) {
+            console.log('BODY', { body, fast: fastBodyParse(body) });
+            req.body = fastBodyParse(body);
+          } else {
+            req.body = JSON.parse(body);
+          }
         } else if (
           urlEncoded &&
           contentType.indexOf('/x-www-form-urlencoded') !== -1
         ) {
           if (typeof urlEncoded === 'object') {
-            req.body = parse(
-              typeof body === 'string' ? body : body.toString(),
-              urlEncoded
-            );
+            req.body = parse(body, urlEncoded);
           } else {
-            req.body = parse(typeof body === 'string' ? body : body.toString());
+            req.body = parse(body);
           }
         }
       }

--- a/src/packed/middlewares/body-parser.js
+++ b/src/packed/middlewares/body-parser.js
@@ -5,24 +5,15 @@ export default ({
   experimentalJsonParse = false,
   urlEncoded = true
 } = {}) => {
-  const middleware = async (req, { fastBodyParse }) => {
+  const middleware = async (req) => {
     const { headers, body } = req;
 
     if (headers && body) {
       const contentType = headers['content-type'];
       if (contentType) {
         if (json && contentType.indexOf('/json') !== -1) {
-          console.log(
-            experimentalJsonParse,
-            fastBodyParse,
-            {
-              check: experimentalJsonParse && fastBodyParse
-            },
-            body
-          );
-          if (experimentalJsonParse && fastBodyParse !== undefined) {
-            console.log('BODY', { body, fast: fastBodyParse(body) });
-            req.body = fastBodyParse(body);
+          if (experimentalJsonParse && req.fastBodyParse !== undefined) {
+            req.body = req.fastBodyParse(body);
           } else {
             req.body = JSON.parse(body);
           }

--- a/src/request-proto/http/body.js
+++ b/src/request-proto/http/body.js
@@ -1,3 +1,5 @@
+const SPACE_TRIM_REGEX = / |\n|\t/g;
+
 export default (req) =>
   req.stream &&
   new Promise((resolve, reject) => {
@@ -8,7 +10,7 @@ export default (req) =>
     });
     req.stream.once('end', () => {
       req.buffer = buffer;
-      req.body = buffer.toString('utf8');
+      req.body = buffer.toString('utf8').replace(SPACE_TRIM_REGEX, '');
       resolve();
     });
     req.stream.once('error', (err) => {


### PR DESCRIPTION
## Feat
- Added new `experimentalJsonParse` option for packed `body-parser` middleware
- - Applies if there exists `{ schema: { body: { ... } } }`
- - Performance improvements up-to 15% for type content of `application/json` and `text/json`
- - It's **Experimental**, be careful, if any of your data is wrong, parsing may not happen
- - We used fork of [turbo-json-parse](https://github.com/mafintosh/turbo-json-parse) and you can find our improved version at [here](https://github.com/dalisoft/turbo-json-parse/tree/fix/validate-throw)