### PR TITLE
Dual CommonJS/ES Module package support

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,14 @@
   "version": "2.1.1",
   "description": "Nano-framework for Node.js",
   "type": "module",
-  "main": "src/nanoexpress.js",
+  "main": "cjs/nanoexpress.js",
   "module": "src/nanoexpress.js",
+  "exports": {
+    ".": "./cjs/nanoexpress.js",
+    "./module": "./src/nanoexpress.js",
+    "./cjs/": "./cjs/",
+    "./src/": "./src/"
+  },
   "typings": "nanoexpress.d.ts",
   "funding": {
     "type": "patreon",


### PR DESCRIPTION
Greetings, Davlat.

Made the `nanoexpress-pro` dual CommonJS/ECMAScript Module (ESM) package.

See: https://nodejs.org/api/esm.html#esm_dual_commonjs_es_module_packages

Description of the `package.json` fields:

* `main` — for CommonJS for backward comparability;
* `module` — for ESM backward comparability with the old proposal, see: https://stackoverflow.com/questions/42708484/what-is-the-module-pack;
* `exports`:
  * `.` — CommonJS;
  * `./module` — ESM;
  * `./cjs/` — allow import files directly for CommonJS;
  * `./src/` — allow import files directly for ESM.

## Examples

## `require()`

Use in CommonJS Node.js applications.

```js
const nanoexpress = require('nanoexpress-pro');
```

### `import`

Use in ESM Node.js applications with:

* argument `--experimental-specifier-resolution=node`;
* `webpack`/`rollup`/`babel`/`esm` package.

```js
import nanoexpress from 'nanoexpress-pro';
```

### `import * as`

Use in TypeScript Node.js applications.

```ts
import * as nanoexpress from 'nanoexpress-pro';
```

Best wishes,
Sergey.

P.S.:

## Pull Request

### Is you/your team sponsoring this project

- [x] Yes
- [ ] No

#### _If your team sponsoring this project, please attach here your team lead or who purchased license GitHub login_

### What you changed

- [x] Code changes
- [ ] Tests changed
- [ ] Typo fixes

#### _If you change code, tests should be passed_
