### PR TITLE
Arrays as route paths

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -201,7 +201,6 @@ export default class App {
 
 const exposeAppMethod = (method) =>
   function (path, ...fns) {
-
     const { _app, _route, _anyRouteCalled } = this;
     var that = this;
     function createRoute(path) {
@@ -224,16 +223,13 @@ const exposeAppMethod = (method) =>
       }
     }
     if (fns.length > 0) {
-
       if (Array.isArray(path)) {
-        for(let n=0; n < path.length; n++) {
+        for (let n = 0; n < path.length; n++) {
           createRoute(path[n]);
         }
-      }
-      else {
+      } else {
         createRoute(path);
       }
-
     }
     return this;
   };

--- a/src/App.js
+++ b/src/App.js
@@ -201,39 +201,39 @@ export default class App {
 
 const exposeAppMethod = (method) =>
   function (path, ...fns) {
-    
+
     const { _app, _route, _anyRouteCalled } = this;
-    var that = this
-    if (fns.length > 0) {
-      
-      function createRoute(path) {
-        const preparedRouteFunction = _route._prepareMethod(
-          method.toUpperCase(),
-          { path, originalUrl: path },
-          ...fns
-        );
-        
-        _app[method](path, preparedRouteFunction);
+    var that = this;
+    function createRoute(path) {
+      const preparedRouteFunction = _route._prepareMethod(
+        method.toUpperCase(),
+        { path, originalUrl: path },
+        ...fns
+      );
 
-        that._routeCalled = true;
+      _app[method](path, preparedRouteFunction);
 
-        if (!_anyRouteCalled && method !== 'options') {
-          that._anyRouteCalled = path === '/*';
-        }
+      that._routeCalled = true;
 
-        if (method === 'options') {
-          that._optionsCalled = true;
-        }
+      if (!_anyRouteCalled && method !== 'options') {
+        that._anyRouteCalled = path === '/*';
       }
+
+      if (method === 'options') {
+        that._optionsCalled = true;
+      }
+    }
+    if (fns.length > 0) {
+
       if (Array.isArray(path)) {
         for(let n=0; n < path.length; n++) {
-          createRoute(path[n])
+          createRoute(path[n]);
         }
       }
       else {
-        createRoute(path)
+        createRoute(path);
       }
-      
+
     }
     return this;
   };

--- a/src/App.js
+++ b/src/App.js
@@ -201,26 +201,39 @@ export default class App {
 
 const exposeAppMethod = (method) =>
   function (path, ...fns) {
+    
     const { _app, _route, _anyRouteCalled } = this;
-
+    var that = this
     if (fns.length > 0) {
-      const preparedRouteFunction = _route._prepareMethod(
-        method.toUpperCase(),
-        { path, originalUrl: path },
-        ...fns
-      );
+      
+      function createRoute(path) {
+        const preparedRouteFunction = _route._prepareMethod(
+          method.toUpperCase(),
+          { path, originalUrl: path },
+          ...fns
+        );
+        
+        _app[method](path, preparedRouteFunction);
 
-      _app[method](path, preparedRouteFunction);
+        that._routeCalled = true;
 
-      this._routeCalled = true;
+        if (!_anyRouteCalled && method !== 'options') {
+          that._anyRouteCalled = path === '/*';
+        }
 
-      if (!_anyRouteCalled && method !== 'options') {
-        this._anyRouteCalled = path === '/*';
+        if (method === 'options') {
+          that._optionsCalled = true;
+        }
       }
-
-      if (method === 'options') {
-        this._optionsCalled = true;
+      if (Array.isArray(path)) {
+        for(let n=0; n < path.length; n++) {
+          createRoute(path[n])
+        }
       }
+      else {
+        createRoute(path)
+      }
+      
     }
     return this;
   };


### PR DESCRIPTION
In express.js, it is possible to create routes with array of paths. This commit enables this functionality in nanoexpress.

```js 
app.get(['/send', '/send2'], (req, res) => {
  return res.send({ status: 'ok' });
});
```

Unfortunately, I haven't worked with jest and couldn't figure out how to make additional new tests for the future.

I will make a pull request to change documentation, if this pull request is accepted.

## Pull Request

### Is you/your team sponsoring this project

- [ ] Yes
- [x] No

#### _If your team sponsoring this project, please attach here your team lead or who purchased license GitHub login_

### What you changed

- [x] Code changes
- [ ] Tests changed
- [ ] Typo fixes

#### _If you change code, tests should be passed_

### Note

- **Your every change to feature/code should be documented**
- **📝 Documentation** fixes should be filled [here](https://github.com/nanoexpress/docs/pulls)
- **🔗 Middlewares** fixes should be filled [here](https://github.com/nanoexpress/middlewares/pulls)
